### PR TITLE
Update Forest_Capital.tmx to give Green rares/mythics for arena rewards

### DIFF
--- a/forge-gui/res/adventure/common/maps/map/main_story/forest_capital.tmx
+++ b/forge-gui/res/adventure/common/maps/map/main_story/forest_capital.tmx
@@ -193,7 +193,8 @@
             &quot;count&quot;: 1,
             &quot;rarity&quot;: [
                 &quot;Rare&quot;
-            ]
+            ],
+            &quot;colors&quot;: [&quot;green&quot;]
         }
     ],[
         {
@@ -213,7 +214,8 @@
             &quot;count&quot;: 2,
             &quot;rarity&quot;: [
                 &quot;Mythic Rare&quot;
-            ]
+            ],
+            &quot;colors&quot;: [&quot;green&quot;]
         }
     ]
     ]


### PR DESCRIPTION
Forest Capital Arena did not give color-specific rares/mythics as rewards, like the other capitals do. This brings the Forest Capital in line with the other capitals.